### PR TITLE
Fixed rebar.config dependencies syntax so they don't require github acco...

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,8 +19,8 @@
 ]}.
 {deps, [
   {lager,  ".*",  {git, "git://github.com/basho/lager.git",  "master"}},
-  {sync,   ".*", {git, "git@github.com:rustyio/sync.git",    "master"}},
-  {gun,    ".*",  {git, "git@github.com:extend/gun.git",     "master"}}
+  {sync,   ".*", {git, "git://github.com/rustyio/sync.git",    "master"}},
+  {gun,    ".*",  {git, "git://github.com/extend/gun.git",     "master"}}
 ]}.
 {xref_warnings, true}.
 {xref_checks, [undefined_function_calls, undefined_functions, locals_not_used, deprecated_function_calls, deprecated_functions]}.


### PR DESCRIPTION
Fixed rebar.config dependencies syntax so they don't require github account validation.