### PR TITLE
[#70] Terminate child so that it is not listed as a worker

### DIFF
--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -90,7 +90,7 @@ stop() ->
 -spec start_link(string(), integer(), connection_type()) ->
     {ok, pid()} | ignore | {error, term()}.
 start_link(Host, Port, Type) ->
-    gen_fsm:start(shotgun, [Host, Port, Type], []).
+    gen_fsm:start_link(shotgun, [Host, Port, Type], []).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% API


### PR DESCRIPTION
Add a call to `supervisor:terminate_child/2` in the `gen_fsm:terminate/1`, otherwise the process is not active but still appears as a worker when calling `supervisor:count_children(shotgun_sup)`.