### PR TITLE
Changes to open and check_uri

### DIFF
--- a/src/shotgun.app.src
+++ b/src/shotgun.app.src
@@ -2,7 +2,7 @@
  [
   {description,
    "better than just a gun"},
-  {vsn, "0.1.12"},
+  {vsn, "0.1.13"},
   {applications,
     [kernel,
      stdlib,

--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -104,14 +104,15 @@ start_link(Host, Port, Type, Opts) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% @equiv get(Host, Port, http, #{})
--spec open(Host :: string(), Port :: integer()) -> {ok, pid()}.
+-spec open(Host :: string(), Port :: integer()) ->
+    {ok, pid()} | {error, gun_open_failed} | {error, gun_timeout}.
 open(Host, Port) ->
     open(Host, Port, http).
 
 -spec open(Host :: string(), Port :: integer(), Type :: connection_type()) ->
-    {ok, pid()};
+    {ok, pid()} | {error, gun_open_failed} | {error, gun_timeout};
     (Host :: string(), Port :: integer(), Opts :: open_opts()) ->
-    {ok, pid()}.
+    {ok, pid()} | {error, gun_open_failed} | {error, gun_timeout}.
 %% @equiv get(Host, Port, Type, #{}) or get(Host, Port, http, Opts)
 open(Host, Port, Type) when is_atom(Type) ->
   open(Host, Port, Type, #{});
@@ -121,7 +122,7 @@ open(Host, Port, Opts) when is_map(Opts) ->
 
 %% @doc Opens a connection of the type provided with the host and port specified and the specified connection timeout and/or Ranch transport options.
 -spec open(Host :: string(), Port :: integer(), Type :: connection_type(), Opts :: open_opts()) ->
-    {ok, pid()}.
+    {ok, pid()} | {error, gun_open_failed} | {error, gun_timeout}.
 open(Host, Port, Type, Opts) ->
     supervisor:start_child(shotgun_sup, [Host, Port, Type, Opts]).
 

--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -569,5 +569,8 @@ sse_events(IsFin, Data, State = #{buffer := Buffer}) ->
     end.
 
 %% @private
-check_uri([$/ | _]) -> ok;
-check_uri(_) -> throw(missing_slash_uri).
+check_uri(U) ->
+  case string:chr(U, $/) of
+    0 -> throw(missing_slash_uri);
+    _ -> ok
+  end.


### PR DESCRIPTION
This PR has three big changes.

e0625fc makes it possible to perform requests on URIs that contain query strings, or URIs that point to files or whatever.

7f9d882 does two things. 1) Allows one to pass Ranch transport options along with the call to shotgun:open. 2) *Sort of* addresses Issue #96 .

The remaining commits are documentation and housekeeping stuff.