### PR TITLE
Add vim modelines.

### DIFF
--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -689,3 +689,5 @@ append_work(Work, State) ->
 %% @private
 get_pending_reqs(State) ->
   maps:get(pending_requests, State).
+
+% vim: et sw=4 sts=4

--- a/src/shotgun_app.erl
+++ b/src/shotgun_app.erl
@@ -14,3 +14,5 @@ start(_StartType, _StartArgs) ->
 -spec stop(term()) -> ok.
 stop(_State) ->
     ok.
+
+% vim: et sw=4 sts=4

--- a/src/shotgun_sup.erl
+++ b/src/shotgun_sup.erl
@@ -19,3 +19,5 @@ init([]) ->
     Procs = [{shotgun, {shotgun, start_link, []},
               temporary, 5000, worker, [shotgun]}],
     {ok, {{simple_one_for_one, 10, 10}, Procs}}.
+
+% vim: et sw=4 sts=4


### PR DESCRIPTION
The standard for the shotgun project appears to be indent-with-spaces and four-space indents.

This adds vim modelines to the bottom of all .erl files in the project that enforce indent-with-spaces and four-space indents.