### PR TITLE
Maybe issue 95 fix

### DIFF
--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -440,7 +440,8 @@ wait_response({gun_response, _Pid, _StreamRef, fin, StatusCode, Headers},
                 gen_fsm:reply(From, {ok, Response}),
                 Responses;
             true ->
-                gen_fsm:reply(From, {ok, Response})
+                gen_fsm:reply(From, {ok, Response}),
+                queue:in(Response, Responses)
         end,
     {next_state, at_rest, State#{responses => NewResponses}, 0};
 wait_response({gun_response, _Pid, _StreamRef, nofin, StatusCode, Headers},


### PR DESCRIPTION
This might fix issue #95 .

~~Do note that this is based on my ```work-cancellation``` branch. As always, I can rebase it if needed.~~ (I found a serious bug in the ```work-cancellation``` branch, so this work is now based on ```master```.)

The following conversation with an Erlang shell demonstrates Shotgun's crash-free operation after this fix is applied (The server that serves ```/events``` is configured to return 401's without a body for any access to that path):
```
1> F=fun() ->
1>   l_all(shotgun),
1>   ensure_all_started(shotgun),
1>   Headers = #{<<"content-type">> => <<"application/json">>, <<"Cookie">> => <<"">>},
1>   {ok, Pid}=shotgun:open("localhost",8080),
1>   io:format("~p~n", [shotgun:get( Pid,  "/events", Headers, #{ async => true, async_mode => sse})]),
1>   io:format("~p~n", [shotgun:events(Pid)]),
1>   shotgun:close(Pid)
1> end.
#Fun<erl_eval.20.54118792>
2> F().
{ok,#{headers => [{<<"server">>,<<"Cowboy">>},
       {<<"date">>,<<"Tue, 10 Nov 2015 09:37:51 GMT">>},
       {<<"content-length">>,<<"0">>}],
      status_code => 401}}
[#{headers => [{<<"server">>,<<"Cowboy">>},
    {<<"date">>,<<"Tue, 10 Nov 2015 09:37:51 GMT">>},
    {<<"content-length">>,<<"0">>}],
   status_code => 401}]
ok
3> 
```
EDIT: and if the server is configured to return a body (along with a 401 status), running the above test program gives us the following result:
```
3> F().
{ok,#{body => <<"hio">>,
      headers => [{<<"server">>,<<"Cowboy">>},
       {<<"date">>,<<"Tue, 10 Nov 2015 09:58:46 GMT">>},
       {<<"content-length">>,<<"3">>}],
      status_code => 401}}
[]
4> 
```
(Notice that the body-less response puts an event in the event queue, but the response containing a body does not. I have no idea if either, both, or neither of these are correct behaviors.)