### PR TITLE
Removal of redundant request/6 clause

### DIFF
--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -471,7 +471,8 @@ wait_response({gun_response, _Pid, _StreamRef, fin, StatusCode, Headers},
                 gen_fsm:reply(From, {ok, Response}),
                 Responses;
             true ->
-                gen_fsm:reply(From, {ok, Response})
+                gen_fsm:reply(From, {ok, Response}),
+                queue:in(Response, Responses)
         end,
     {next_state, at_rest, State#{responses => NewResponses}, 0};
 wait_response({gun_response, _Pid, _StreamRef, nofin, StatusCode, Headers},


### PR DESCRIPTION
It looks like the second ```request/6``` clause is redundant. This commit removes it and makes the first clause work with any HTTP method.

Testing demonstrates that GET, POST, and DELETE work. Inspection of the code indicates that there's no reason why async GET won't work.

This is based on my ```maybe-issue-95-fix``` branch, and can -as always- be rebased as needed.