### PR TITLE
Rewrite deps to work with rebar2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,8 @@
+case erlang:function_exported(rebar3, main, 1) of
+    true -> % rebar3
+        CONFIG;
+    false -> % rebar 2.x
+        [{deps, [
+            {gun, ".*", {git, "git://github.com/ninenines/gun.git", "1.0.0-pre.1"}}
+        ]} | lists:keydelete(deps, 1, CONFIG)]
+end.


### PR DESCRIPTION
This small rebar.config script rewrites deps from rebar.config so that it's possible to use shotgun with a project compiled with rebar2.