### PR TITLE
Compile on erlang 17 and18

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,8 @@
+case erlang:function_exported(rebar3, main, 1) of
+    true -> % rebar3
+        CONFIG;
+    false -> % rebar 2.x
+        [{deps, [
+            {gun, ".*", {git, "git://github.com/ninenines/gun.git", "1.0.0-pre.1"}}
+        ]} | lists:keydelete(deps, 1, CONFIG)]
+end.

--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -335,18 +335,18 @@ parse_event(EventBin) ->
 %% gen_fsm callbacks
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--type state() :: #{ async            := boolean()
-                  , async_mode       := false | binary | sse
-                  , buffer           := binary()
-                  , data             := binary()
-                  , from             := term()
-                  , handle_event     := term()
-                  , headers          := term()
-                  , pending_requests := queue:queue() | undefined
-                  , pid              := pid() | undefined
-                  , responses        := queue:queue() | undefined
-                  , status_code      := integer() | undefined
-                  , stream           := reference() | undefined}.
+-type state() :: #{ async            => boolean()
+                  , async_mode       => false | binary | sse
+                  , buffer           => binary()
+                  , data             => binary()
+                  , from             => term()
+                  , handle_event     => term()
+                  , headers          => term()
+                  , pending_requests => queue:queue() | undefined
+                  , pid              => pid() | undefined
+                  , responses        => queue:queue() | undefined
+                  , status_code      => integer() | undefined
+                  , stream           => reference() | undefined}.
 
 %% @private
 -spec init([{string(), integer(), connection_type(), open_opts()}]) ->


### PR DESCRIPTION
This PR changes the `state` type definition to be compatible with Erlang/OTP 17 and 18.

Goes on top of #165.