### PR TITLE
Upgrade to stable gun, fix tests

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,8 +24,8 @@
   {test, [
     {deps, [ {katana_test, {git, "https://github.com/inaka/katana-test.git", {tag, "0.0.6"}}}
            , {mixer,       {git, "https://github.com/inaka/mixer.git",       {tag, "0.1.5"}}}
-           , {cowboy,      {git, "https://github.com/ninenines/cowboy.git",  {tag, "2.0.0-pre.3"}}}
-           , {lasse,       {git, "https://github.com/inaka/lasse.git",       {tag, "cowboy2"}}}
+           , {cowboy,      {git, "https://github.com/ninenines/cowboy.git",  {tag, "2.4.0"}}}
+           , {lasse,       {git, "https://github.com/inaka/lasse.git",       {tag, "1.2.0"}}}
     ]}
   ]},
   {shell, [
@@ -63,7 +63,7 @@
 
 %% == Dependencies ==
 
-{deps, [{gun, "1.0.0-pre.1"}]}.
+{deps, [{gun, {git, "https://github.com/ninenines/gun", {tag, "1.3.0"}}}]}.
 
 %% == Dialyzer ==
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,3 +1,8 @@
-[{<<"cowlib">>,{pkg,<<"cowlib">>,<<"1.3.0">>},1},
- {<<"gun">>,{pkg,<<"gun">>,<<"1.0.0-pre.1">>},0},
- {<<"ranch">>,{pkg,<<"ranch">>,<<"1.1.0">>},1}].
+[{<<"cowlib">>,
+  {git,"https://github.com/ninenines/cowlib",
+       {ref,"106ba84bb04537879d8ce59321a04e0682110b91"}},
+  1},
+ {<<"gun">>,
+  {git,"https://github.com/ninenines/gun",
+       {ref,"e7dd9f227e46979d8073e71c683395a809b78cb4"}},
+  0}].

--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -379,7 +379,10 @@ init([{Host, Port, Type, Opts}]) ->
       %the requested connection. This bubbles up through gun:await_up.
       {error, normal} ->
         {stop, gun_open_failed};
-      {error, {shutdown, nxdomain}} ->
+      %gun can terminate with reason {shutdown, nxdomain}; however, that's not
+      %explicitly specced and makes dialyzer unhappy, so we loosely pattern
+      %match it here.
+      {error, _} ->
         {stop, gun_open_failed}
     end.
 

--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -378,6 +378,8 @@ init([{Host, Port, Type, Opts}]) ->
       %gun currently terminates with reason normal if gun:open fails to open
       %the requested connection. This bubbles up through gun:await_up.
       {error, normal} ->
+        {stop, gun_open_failed};
+      {error, {shutdown, nxdomain}} ->
         {stop, gun_open_failed}
     end.
 

--- a/test/http_server/http_binary_handler.erl
+++ b/test/http_server/http_binary_handler.erl
@@ -10,9 +10,11 @@
 init(Req, _Opts) ->
   case cowboy_req:method(Req) of
     <<"GET">>  ->
-      Headers = [{<<"content-type">>, <<"text/event-stream">>},
-                 {<<"cache-control">>, <<"no-cache">>}],
-      Req1 = cowboy_req:chunked_reply(200, Headers, Req),
+      Headers = #{
+        <<"content-type">> => <<"text/event-stream">>,
+        <<"cache-control">> => <<"no-cache">>
+      },
+      Req1 = cowboy_req:stream_reply(200, Headers, Req),
       shotgun_test_utils:auto_send(count),
       {cowboy_loop, Req1, 1};
     _OtherMethod ->
@@ -29,7 +31,7 @@ info(count, Req, Count) ->
     true  ->
           {stop, Req, 0};
     false ->
-          ok = cowboy_req:chunk(integer_to_binary(Count), Req),
+          ok = cowboy_req:stream_body(integer_to_binary(Count), nofin, Req),
           shotgun_test_utils:auto_send(count),
          {ok, Req, Count + 1}
   end.

--- a/test/http_server/http_server.erl
+++ b/test/http_server/http_server.erl
@@ -48,16 +48,8 @@ start_phase(start_cowboy_http, _StartType, []) ->
          }
         ],
   Dispatch = cowboy_router:compile(Routes),
-  RanchOptions = [{port, Port}],
-  CowboyOptions =
-    [
-     {env,
-      [
-       {dispatch, Dispatch}
-      ]},
-     {compress, true},
-     {timeout, 12000}
-    ],
+  TransportOptions = [{port, Port}],
+  ProtocolOptions = #{env => #{dispatch => Dispatch}},
   {ok, _} =
-    cowboy:start_http(http_server, ListenerCount, RanchOptions, CowboyOptions),
+    cowboy:start_clear(http_server, TransportOptions, ProtocolOptions),
   ok.

--- a/test/http_server/http_server.erl
+++ b/test/http_server/http_server.erl
@@ -41,7 +41,6 @@ start_phase(start_cowboy_http, _StartType, []) ->
         [{ '_'
          , [ {"/",                     http_simple_handler, []}
            , {"/basic-auth",           http_basic_auth_handler, []}
-
            , {"/chunked-sse[/:count]", lasse_handler, [http_sse_handler]}
            , {"/chunked-binary",       http_binary_handler, []}
            ]

--- a/test/http_server/http_simple_handler.erl
+++ b/test/http_server/http_simple_handler.erl
@@ -42,7 +42,7 @@ handle_get(Req, State) ->
   {Body, Req, State}.
 
 handle_post(Req, State) ->
-  {ok, Data, Req1} = cowboy_req:body(Req),
+  {ok, Data, Req1} = cowboy_req:read_body(Req),
   Method = cowboy_req:method(Req1),
   Body = [Method, <<": ">>, Data],
   Req2 = cowboy_req:set_resp_body(Body, Req1),

--- a/test/shotgun_meta_SUITE.erl
+++ b/test/shotgun_meta_SUITE.erl
@@ -4,5 +4,9 @@
 -mixin([ktn_meta_SUITE]).
 
 -export([init_per_suite/1]).
+-export([end_per_suite/1]).
 
 init_per_suite(Config) -> [{application, shotgun} | Config].
+
+end_per_suite(Config) ->
+  Config.


### PR DESCRIPTION
This PR updates shotgun to stable gun 1.3.0. It also updates lasse and cowboy test dependencies to their corresponding stable versions, and fixes #173 so that all existing tests pass.

Notes:
- I don't have xref set up, so I can't tell if that (still) works
- I haven't done any real world testing, just made all current test pass with updated dependencies