### PR TITLE
Update legacy rebar to gun 1.3.0 too

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -3,6 +3,6 @@ case erlang:function_exported(rebar3, main, 1) of
         CONFIG;
     false -> % rebar 2.x
         [{deps, [
-            {gun, ".*", {git, "git://github.com/ninenines/gun.git", "1.0.0-pre.1"}}
+            {gun, ".*", {git, "https://github.com/ninenines/gun.git", "1.3.0"}}
         ]} | lists:keydelete(deps, 1, CONFIG)]
 end.


### PR DESCRIPTION
This is a followup to #174 where I missed rebar2 deps - this updates gun dependency to 1.3.0 for legacy rebar as well. Sorry for the PR spam.