### PR TITLE
Fix dialyzer warning for gun_opts

### DIFF
--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -79,6 +79,8 @@
            %% timeout is passed to gun:await_up. Default if not specified
            %% is 5000 ms.
          , timeout => timeout()
+           %% gun_opts are passed to gun:open
+         , gun_opts => gun:opts()
          }.
 
 -type connection() :: pid().


### PR DESCRIPTION
If you pass `gun_opts` to shotgun, dialyzer will complain about it. It is because the `open_opts` map spec was missing that map key. No longer, fixed by this PR.