### PR TITLE
Left trim optional spaces in event field values

### DIFF
--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -321,12 +321,15 @@ parse_event(EventBin) ->
     FoldFun =
         fun(Line, #{data := Data} = Event) ->
                 case Line of
-                    <<"data: ", NewData/binary>> ->
-                        Event#{data => <<Data/binary, NewData/binary, "\n">>};
-                    <<"id: ", Id/binary>> ->
-                        Event#{id => Id};
-                    <<"event: ", EventName/binary>> ->
-                        Event#{event => EventName};
+                    <<"data:", NewData/binary>> ->
+                        TrimmedNewData = binary_ltrim(NewData),
+                        Event#{
+                            data => <<Data/binary, TrimmedNewData/binary, "\n">>
+                        };
+                    <<"id:", Id/binary>> ->
+                        Event#{id => binary_ltrim(Id)};
+                    <<"event:", EventName/binary>> ->
+                        Event#{event => binary_ltrim(EventName)};
                     <<_Comment/binary>> ->
                         Event
                 end
@@ -785,3 +788,10 @@ get_work(State) ->
 append_work(Work, State) ->
     #{pending_requests := PendingReqs} = State,
     State#{pending_requests := queue:in(Work, PendingReqs)}.
+
+%% @private
+-spec binary_ltrim(binary()) -> binary().
+binary_ltrim(<<32, Bin/binary>>) ->
+    binary_ltrim(Bin);
+binary_ltrim(Bin) ->
+    Bin.

--- a/test/shotgun_unit_SUITE.erl
+++ b/test/shotgun_unit_SUITE.erl
@@ -1,0 +1,98 @@
+-module(shotgun_unit_SUITE).
+
+-export([ all/0
+    , init_per_suite/1
+    , end_per_suite/1
+    , init_per_testcase/2
+    , end_per_testcase/2
+]).
+
+-export([ parse_event/1
+    , parse_event_optional_spaces/1
+    , parse_event_extra_fields/1
+    , parse_event_mixed_order/1
+    , parse_event_minimal/1
+    , parse_event_empty/1
+    , parse_event_multiline_data/1
+]).
+
+-include_lib("common_test/include/ct.hrl").
+
+%%------------------------------------------------------------------------------
+%% Common Test
+%%------------------------------------------------------------------------------
+
+-spec all() -> [atom()].
+all() -> shotgun_test_utils:all(?MODULE).
+
+-spec init_per_suite(shotgun_test_utils:config()) ->
+    shotgun_test_utils:config().
+init_per_suite(Config) ->
+    Config.
+
+-spec end_per_suite(shotgun_test_utils:config()) -> shotgun_test_utils:config().
+end_per_suite(Config) ->
+    Config.
+
+-spec init_per_testcase(atom(), shotgun_test_utils:config()) ->
+    shotgun_test_utils:config().
+init_per_testcase(_, Config) ->
+    Config.
+
+-spec end_per_testcase(atom(), shotgun_test_utils:config()) ->
+    shotgun_test_utils:config().
+end_per_testcase(_, Config) ->
+    Config.
+
+%%------------------------------------------------------------------------------
+%% Test Cases
+%%------------------------------------------------------------------------------
+
+-spec parse_event(shotgun_test_utils:config()) -> {comment, string()}.
+parse_event(_Config) ->
+    EventBin = <<"data:foo\nid:bar\nevent:baz">>,
+    Expected = #{id => <<"bar">>, event => <<"baz">>, data => <<"foo\n">>},
+    Expected = shotgun:parse_event(EventBin),
+    {comment, ""}.
+
+-spec parse_event_optional_spaces(shotgun_test_utils:config()) -> {comment, string()}.
+parse_event_optional_spaces(_Config) ->
+    EventBin = <<"data: foo\nid: bar\nevent: baz">>,
+    Expected = #{id => <<"bar">>, event => <<"baz">>, data => <<"foo\n">>},
+    Expected = shotgun:parse_event(EventBin),
+    {comment, ""}.
+
+-spec parse_event_extra_fields(shotgun_test_utils:config()) -> {comment, string()}.
+parse_event_extra_fields(_Config) ->
+    EventBin = <<"data:foo\nid:bar\nevent:baz\nextra:should-be-dropped">>,
+    Expected = #{id => <<"bar">>, event => <<"baz">>, data => <<"foo\n">>},
+    Expected = shotgun:parse_event(EventBin),
+    {comment, ""}.
+
+-spec parse_event_mixed_order(shotgun_test_utils:config()) -> {comment, string()}.
+parse_event_mixed_order(_Config) ->
+    EventBin = <<"id:bar\nextra:should-be-dropped\ndata:foo\nevent:baz">>,
+    Expected = #{id => <<"bar">>, event => <<"baz">>, data => <<"foo\n">>},
+    Expected = shotgun:parse_event(EventBin),
+    {comment, ""}.
+
+-spec parse_event_minimal(shotgun_test_utils:config()) -> {comment, string()}.
+parse_event_minimal(_Config) ->
+    EventBin = <<"id:bar">>,
+    Expected = #{id => <<"bar">>, data => <<>>},
+    Expected = shotgun:parse_event(EventBin),
+    {comment, ""}.
+
+-spec parse_event_empty(shotgun_test_utils:config()) -> {comment, string()}.
+parse_event_empty(_Config) ->
+    EventBin = <<"">>,
+    Expected = #{data => <<>>},
+    Expected = shotgun:parse_event(EventBin),
+    {comment, ""}.
+
+-spec parse_event_multiline_data(shotgun_test_utils:config()) -> {comment, string()}.
+parse_event_multiline_data(_Config) ->
+    EventBin = <<"data:foo1\ndata:foo2\ndata:foo3\nid:bar\nevent:baz">>,
+    Expected = #{id => <<"bar">>, event => <<"baz">>, data => <<"foo1\nfoo2\nfoo3\n">>},
+    Expected = shotgun:parse_event(EventBin),
+    {comment, ""}.

--- a/test/shotgun_unit_SUITE.erl
+++ b/test/shotgun_unit_SUITE.erl
@@ -1,11 +1,6 @@
 -module(shotgun_unit_SUITE).
 
--export([ all/0
-    , init_per_suite/1
-    , end_per_suite/1
-    , init_per_testcase/2
-    , end_per_testcase/2
-]).
+-export([ all/0 ]).
 
 -export([ parse_event/1
     , parse_event_optional_spaces/1
@@ -24,25 +19,6 @@
 
 -spec all() -> [atom()].
 all() -> shotgun_test_utils:all(?MODULE).
-
--spec init_per_suite(shotgun_test_utils:config()) ->
-    shotgun_test_utils:config().
-init_per_suite(Config) ->
-    Config.
-
--spec end_per_suite(shotgun_test_utils:config()) -> shotgun_test_utils:config().
-end_per_suite(Config) ->
-    Config.
-
--spec init_per_testcase(atom(), shotgun_test_utils:config()) ->
-    shotgun_test_utils:config().
-init_per_testcase(_, Config) ->
-    Config.
-
--spec end_per_testcase(atom(), shotgun_test_utils:config()) ->
-    shotgun_test_utils:config().
-end_per_testcase(_, Config) ->
-    Config.
 
 %%------------------------------------------------------------------------------
 %% Test Cases


### PR DESCRIPTION
The [SSE spec](https://www.w3.org/TR/2009/WD-eventsource-20091029/#parsing-an-event-stream) says that space(s) after a `:` when parsing event stream are optional. Currently `shotgun` requires one space. Here I trim these insignificant spaces to be compatible with the spec. SSE tests still pass because `lasse` appears to always send that optional space.