### PR TITLE
Migrate from gen_fsm to gen_statem

### DIFF
--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -538,12 +538,12 @@ receive_data(cast, {gun_data, _Pid, StreamRef, nofin, Data},
     {next_state, receive_data, State#{data => NewData}};
 receive_data(cast, {gun_data, _Pid, _StreamRef, fin, Data},
              #{data := DataAcc, from := From, status_code
-             := StatusCode, headers := Headers} = State) ->
+               := StatusCode, headers := Headers} = State) ->
     NewData = <<DataAcc/binary, Data/binary>>,
     Result = {ok, #{status_code => StatusCode,
-        headers => Headers,
-        body => NewData
-    }},
+                    headers => Headers,
+                    body => NewData
+                   }},
     gen_statem:reply(From, Result),
     {next_state, at_rest, State, 0};
 receive_data(cast, {gun_error, _Pid, StreamRef, _Reason},

--- a/test/shotgun_SUITE.erl
+++ b/test/shotgun_SUITE.erl
@@ -195,7 +195,7 @@ complete_coverage(Config) ->
   Conn = ?config(conn, Config),
 
   ct:comment("Sending unexpected events should return an error"),
-  {error, {unexpected, whatever}} = gen_fsm:sync_send_event(Conn, whatever),
+  {error, {unexpected, whatever}} = gen_statem:call(Conn, whatever),
   {error, {unexpected, _}} = shotgun:data(Conn, <<"data">>),
 
   ct:comment("gen_server's code_change"),


### PR DESCRIPTION
This PR addresses #178 and migrates shotgun from `gen_fsm` to `gen_statem` because `gen_fsm` is being deprecated.

Notes: This should just be a straight migration - I didn't change any functionality. I took the opportunity to rename `State` variables to `StateData` to better match `gen_statem` terminology.