### PR TITLE
Correct type definition of the type response/0

### DIFF
--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -89,7 +89,7 @@
          }.
 
 -type response() :: #{ status_code => integer()
-                     , header => map()
+                     , headers => map()
                      , body => binary()
                      }.
 


### PR DESCRIPTION
This fixes an issue where the type spec mentions `header` but the code uses `headers`.

Fix #168 