### PR TITLE
Fix the type definition of the response headers.

### DIFF
--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -89,7 +89,7 @@
          }.
 
 -type response() :: #{ status_code => integer()
-                     , headers => map()
+                     , headers => proplists:proplist()
                      , body => binary()
                      }.
 


### PR DESCRIPTION
This fixes an issue where the type of the response headers is defined to be a map but is in fact a list.

I considered making it a `[ {binary(), binary()} ]` but that seems to be too restrictive considering other code and type specs.

Fix #188 