### PR TITLE
split transport_opts into tcp_opts and tls_opts for gun2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -63,7 +63,7 @@
 
 %% == Dependencies ==
 
-{deps, [{gun, "1.3.1"}]}.
+{deps, [{gun, {git, "https://github.com/ninenines/gun.git", {tag, "2.0.0-rc.2"}}}]}.
 
 %% == Dialyzer ==
 

--- a/rebar.config
+++ b/rebar.config
@@ -63,7 +63,7 @@
 
 %% == Dependencies ==
 
-{deps, [{gun, {git, "https://github.com/ninenines/gun.git", {tag, "2.0.0-rc.2"}}}]}.
+{deps, [{gun, "2.0.0"}]}.
 
 %% == Dialyzer ==
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -3,6 +3,6 @@ case erlang:function_exported(rebar3, main, 1) of
         CONFIG;
     false -> % rebar 2.x
         [{deps, [
-            {gun, ".*", {git, "https://github.com/ninenines/gun.git", "1.3.0"}}
+            {gun, {git, "https://github.com/ninenines/gun.git", {tag, "2.0.0-rc.2"}}}
         ]} | lists:keydelete(deps, 1, CONFIG)]
 end.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -3,6 +3,6 @@ case erlang:function_exported(rebar3, main, 1) of
         CONFIG;
     false -> % rebar 2.x
         [{deps, [
-            {gun, {git, "https://github.com/ninenines/gun.git", {tag, "2.0.0-rc.2"}}}
+            {gun, ".*", {git, "https://github.com/ninenines/gun.git", "2.0.0"}}
         ]} | lists:keydelete(deps, 1, CONFIG)]
 end.

--- a/src/shotgun.erl
+++ b/src/shotgun.erl
@@ -358,13 +358,15 @@ init([{Host, Port, Type, Opts}]) ->
                   http -> tcp;
                   https -> ssl
               end,
-    TransportOpts = maps:get(transport_opts, Opts, []),
+    TcpOpts = maps:get(tcp_opts, Opts, []),
+    TlsOpts = maps:get(tls_opts, Opts, []),
     PassedGunOpts = maps:get(gun_opts, Opts, #{}),
     DefaultGunOpts = #{
-                transport      => GunType,
-                retry          => 1,
-                retry_timeout  => 1,
-                transport_opts => TransportOpts
+                transport     => GunType,
+                retry         => 1,
+                retry_timeout => 1,
+                tcp_opts      => TcpOpts,
+                tls_opts      => TlsOpts
                },
     GunOpts = maps:merge(DefaultGunOpts, PassedGunOpts),
     Timeout = maps:get(timeout, Opts, 5000),


### PR DESCRIPTION
This makes shotgun compatible with `gun` v2 (and incompatible with `gun` v1)
`gun` v2 has been in RC for a while now
https://github.com/inaka/shotgun/issues/193